### PR TITLE
Publish to maven using sbt-ci-release

### DIFF
--- a/.github/workflows/continouos-delivery.yml
+++ b/.github/workflows/continouos-delivery.yml
@@ -1,0 +1,28 @@
+# Continuous Integration (CI) to Build & Test & Coverage & Lint.
+# ~~
+name: CI
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    name: Publish to Maven
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: '11'
+          cache: 'sbt'
+
+      - name: Publish package
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/continouos-integration.yml
+++ b/.github/workflows/continouos-integration.yml
@@ -3,9 +3,9 @@
 name: CI
 on:
   pull_request:
-    branches: [ '**' ]
+    branches: [ main, '**' ]
   push:
-    branches: [ '**' ]
+    branches: [ main ]
 
 jobs:
   validate:
@@ -28,18 +28,24 @@ jobs:
     name: Build & Test
     needs: [ validate ]
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        scala: [ '2.12.17', '2.13.10' ]
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
-          distribution: corretto
-          java-version: '11'
+          distribution: 'corretto'
+          java-version: '8'
           cache: 'sbt'
 
       - name: Build & Test
-        run: sbt testWithCoverage
+        run: sbt ++${{ matrix.scala }} testWithCoverage
 
       - name: Upload coverage report (Cobertura)
         uses: actions/upload-artifact@v3.1.0
@@ -52,6 +58,39 @@ jobs:
         with:
           name: scoverage-report-html
           path: ${{github.workspace}}/target/scala-2.13/scoverage-report/
+
+  optional-build:
+    name: Build (Optional)
+    continue-on-error: ${{ matrix.experimental }}
+    needs: [ validate ]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        distribution: [ 'corretto' ]
+        jdk: [ '11' ]
+        scala: [ '2.12.17', '2.13.10' ]
+        experimental: [ false ]
+        include:
+          - jdk: '17'
+            distribution: 'corretto'
+            scala: '2.13.10'
+            experimental: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.jdk }}
+          cache: 'sbt'
+
+      - name: Perform Build / Test
+        run: sbt ++${{ matrix.scala }} compile test
 
   coverage:
     name: Coverage Report
@@ -75,3 +114,11 @@ jobs:
           show_class_names: true
           link_missing_lines: true
           minimum_coverage: 75
+
+  ready-to-merge:
+    name: Ready to Merge
+    if: ${{ github.event.pull_request }}
+    needs: [ optional-build, coverage ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Ready to merge.'

--- a/build.sbt
+++ b/build.sbt
@@ -1,48 +1,33 @@
+import Common._
+import Dependencies.Version.scala212
+import Dependencies.Version.scala213
+
 name := """play-hmac-signatures"""
 
-version := "0.3"
-
-organization := "com.mesonomics"
-
-homepage := Some(url("https://github.com/phelps-sg/play-hmac-signatures"))
-
-scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/phelps-sg/play-hmac-signatures"),
-    "git@github.com:phelps-sg/play-hmac-signatures.git"
-  )
-)
-
-developers := List(
-  Developer(
-    "phelps-sg",
-    "Steve Phelps",
-    "sphelps@sphelps.net",
-    url("https://github.com/usernamehttps://github.com/phelps-sg")
-  )
-)
-
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
-
-publishMavenStyle := true
-
-publishTo := Some(
-  if (isSnapshot.value)
-    Opts.resolver.sonatypeSnapshots
-  else
-    Opts.resolver.sonatypeStaging
-)
-
-enablePlugins(Dependencies)
+enablePlugins(Common, Dependencies)
 
 inThisBuild(
   List(
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala212, scala213),
     scalafixScalaBinaryVersion := "2.13",
+    versionScheme := Some("early-semver"),
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     scalacOptions += "-Ywarn-unused",
-    scalacOptions += "-Xcheckinit"
+    scalacOptions += "-Xcheckinit",
+    sonatypePublishTo := Some({
+      if (isSnapshot.value)
+        Opts.resolver.sonatypeOssSnapshots.head
+      else
+        Opts.resolver.sonatypeStaging
+    }),
+    scmInfo := Some(
+      ScmInfo(
+        url(s"https://github.com/$gitAccount/$repoName"),
+        s"git@github.com:$gitAccount/$repoName.git"
+      )
+    )
   )
 )
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+
+object Common extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = JvmPlugin
+
+  val gitAccount = "phelps-sg"
+  val repoName = "play-hmac-signatures"
+
+  import Dependencies.Version._
+
+  override def globalSettings: Seq[Setting[_]] =
+    Seq(
+      // project
+      description := "A Play! Framework dependency to validate an HMAC signature in a HTTP request.",
+      // organization
+      organization := "com.mesonomics",
+      organizationName := "Mesonomics",
+      organizationHomepage := Some(
+        url(s"https://github.com/$gitAccount/$repoName")
+      ),
+      // scala settings
+      scalaVersion := scala213,
+      scalacOptions ++= Seq(
+        "-deprecation",
+        "-feature",
+        "-unchecked",
+        "-encoding",
+        "utf8"
+      ),
+      javacOptions ++= Seq("-encoding", "UTF-8"),
+      // legal
+      licenses := Seq(
+        "Apache-2.0" ->
+          url(s"https://github.com/$gitAccount/$repoName/blob/main/LICENSE")
+      ),
+      // on the web
+      homepage := Some(url(s"https://github.com/$gitAccount/$repoName")),
+      developers += Developer(
+        "contributors",
+        "Contributors",
+        s"https://github.com/$gitAccount/$repoName/graphs/contributors",
+        url(s"https://github.com/$gitAccount")
+      )
+    )
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,3 @@
-/*
- * Copyright (C) 2021 Just Play LTDA.
- * See the LICENCE.txt file distributed with this work for additional
- * information regarding copyright ownership.
- */
-
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
@@ -11,13 +5,17 @@ import sbt.plugins.JvmPlugin
 object Dependencies extends AutoPlugin {
 
   object Version {
+    val scala212 = "2.12.17"
+    val scala213 = "2.13.10"
+
     val play = "2.8.18"
     val guice = "5.1.0"
+    val jackson = "2.13.4"
+
     val scalatic = "3.2.14"
+    val scalaMock = "5.2.0"
     val scalaTest = "3.2.14"
     val scalaTestPlus = "5.1.0"
-    val scalaMock = "5.2.0"
-    val jackson = "2.13.4"
   }
 
   override def trigger: PluginTrigger = allRequirements

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,11 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.14")
+
+// CI Release plugin.
+// ~
+// This is an sbt plugin to help automate releases to Sonatype and Maven Central from GitHub Actions.
+// See more: https://github.com/sbt/sbt-ci-release
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 
 // Test Coverage plugin.
 // ~

--- a/src/main/scala/com/mesonomics/playhmacsignatures/SignatureVerifyAction.scala
+++ b/src/main/scala/com/mesonomics/playhmacsignatures/SignatureVerifyAction.scala
@@ -143,7 +143,7 @@ abstract class SignatureVerifyAction(
       } catch {
         case _: NumberFormatException =>
           None
-        case ex =>
+        case ex: Exception =>
           throw ex
       }
     }

--- a/src/main/scala/com/mesonomics/playhmacsignatures/SignatureVerifyAction.scala
+++ b/src/main/scala/com/mesonomics/playhmacsignatures/SignatureVerifyAction.scala
@@ -137,8 +137,15 @@ abstract class SignatureVerifyAction(
     )(_, _, _)
 
   protected def getTimestamp[A](request: Request[A]): Option[Long] =
-    request.headers.get(headerKeyTimestamp) flatMap {
-      _.toLongOption
+    request.headers.get(headerKeyTimestamp) flatMap { timestampStr =>
+      try {
+        Some(timestampStr.toLong)
+      } catch {
+        case _: NumberFormatException =>
+          None
+        case ex =>
+          throw ex
+      }
     }
 
   protected def getSignature[A](request: Request[A]): Option[ByteString] =

--- a/src/test/scala/ControllerTests.scala
+++ b/src/test/scala/ControllerTests.scala
@@ -21,7 +21,6 @@ import play.api.mvc.BodyParsers
 import play.api.test.Helpers.{POST, defaultAwaitTimeout, status}
 import play.api.test.{FakeRequest, Helpers}
 
-import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 
@@ -81,9 +80,7 @@ class ControllerTests
 
       val fakeRequest = FakeRequest(POST, "/")
         .withBody(body)
-        .withHeaders(
-          ArraySeq.unsafeWrapArray(signatureHeaders): _*
-        )
+        .withHeaders(signatureHeaders: _*)
 
       val result = testController.test().apply(fakeRequest)
       status(result) mustEqual UNAUTHORIZED
@@ -104,9 +101,7 @@ class ControllerTests
 
       val fakeRequest = FakeRequest(POST, "/")
         .withBody(body)
-        .withHeaders(
-          ArraySeq.unsafeWrapArray(signatureHeaders): _*
-        )
+        .withHeaders(signatureHeaders: _*)
 
       val result = testController.test().apply(fakeRequest)
       status(result) mustEqual OK


### PR DESCRIPTION
Implement GitHub action to publish to maven using `sbt-ci-release` plugin.
We won't need to set the sbt project version because it's using `sbt-dynver` and will get the release tag value.

@phelps-sg you must create some secrets before merging it.
More infos at: [sbt-ci-release project](https://github.com/sbt/sbt-ci-release#gpg)

- PGP_PASSPHRASE
- PGP_SECRET
- SONATYPE_PASSWORD
- SONATYPE_USERNAME

Fixes #2 