### PR TITLE
Rename action to CD

### DIFF
--- a/.github/workflows/continouos-delivery.yml
+++ b/.github/workflows/continouos-delivery.yml
@@ -1,6 +1,6 @@
 # Continuous Integration (CI) to Build & Test & Coverage & Lint.
 # ~~
-name: CI
+name: CD
 on:
   release:
     types: [ created ]


### PR DESCRIPTION
Improving GitHub Actions name to help to know better into Actions tab option.